### PR TITLE
Slim down image size by about 100 MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,18 @@ FROM debian:wheezy
 
 MAINTAINER ZOL <hello@zol.fr>
 
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get update && apt-get install -y \
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -q -y \
     libsqlite3-dev \
     ruby \
     ruby-dev \
-    rubygems
+    build-essential \
+  && gem install --no-ri --no-rdoc mailcatcher \
+  && apt-get remove -y build-essential \
+  && apt-get autoremove -y \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists
 
-RUN gem install mailcatcher
-
-EXPOSE 1080
-EXPOSE 1025
+EXPOSE 1080 1025
 
 ENTRYPOINT ["mailcatcher", "--smtp-ip=0.0.0.0", "--http-ip=0.0.0.0", "--foreground"]


### PR DESCRIPTION
Some changes to slim down the image size:
- Remove build dependencies when done installing gem
- Install gem without documentation
- Cleanup apt cache and lists
- Squash EXPOSE and ENV layers

I use this in a fig environment and strive to have small images so developer bootstrap and recreating environments can be as fast as possible. If these changes are unwanted I'll keep them in my fork and build a new image.

``` console
$ docker images
REPOSITORY                 TAG                 IMAGE ID            CREATED              VIRTUAL SIZE
mailcatcher                slim                4210c22b4dfb        About a minute ago   235.8 MB
mailcatcher                original            68ae97bfd56e        4 minutes ago        334.9 MB
```
