### PR TITLE
Trim off 200 MB of fat with Alpine as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,9 @@
-FROM debian:wheezy
-
+FROM alpine:3.2
 MAINTAINER ZOL <hello@zol.fr>
-
-RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get install -q -y \
-    libsqlite3-dev \
-    ruby \
-    ruby-dev \
-    build-essential \
+RUN apk -U add ruby ruby-bigdecimal ruby-sqlite tzdata libstdc++ \
+  && apk add -t build ruby-dev build-base \
   && gem install --no-ri --no-rdoc mailcatcher \
-  && apt-get remove -y build-essential \
-  && apt-get autoremove -y \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists
-
+  && apk del --purge build \
+  && rm -rf /var/cache/apk/*
 EXPOSE 1080 1025
-
 ENTRYPOINT ["mailcatcher", "--smtp-ip=0.0.0.0", "--http-ip=0.0.0.0", "--foreground"]


### PR DESCRIPTION
Basing off Alpine Linux can get us down to around 34 MB. It is much faster for initial pull now. This is a more drastic change so feel free to close if not interested.
